### PR TITLE
Re-enable PROMPT_COMMAND

### DIFF
--- a/core/prompt.sh
+++ b/core/prompt.sh
@@ -35,4 +35,4 @@ function __filtered_git_ps1_emoji {
 PS1="
 $IPurple\w$Color_Off\$(__filtered_git_ps1_emoji)$Red\$(rb_ver)$Blue\$(rails_e)$Color_Off
 $Green>$Color_Off "
-#PROMPT_COMMAND='echo -ne "\033]0; ${PWD/#$HOME/~}\007"'
+PROMPT_COMMAND='echo -ne "\033]0; ${PWD/#$HOME/~}\007"'


### PR DESCRIPTION
Re- enabled PROMPT_COMMAND to fix iterm tab titles.


![image](https://user-images.githubusercontent.com/28196/40782534-a27f618a-64ad-11e8-86c5-177b6ab908bc.png)
